### PR TITLE
Allow separate save directories for multiple installs of one mod

### DIFF
--- a/launcher/game/preferences.rpy
+++ b/launcher/game/preferences.rpy
@@ -210,6 +210,8 @@ screen preferences:
                         if persistent.b_ddml:
                             textbutton _("Build DDML") style "l_nonbox" action [project.Select("launcher"), Jump("build_distributions")]
 
+                        textbutton _("Separate Save Data Per Install") style "l_checkbox" action [ToggleField(persistent, "separate_saves")]
+
                 frame:
                     style "l_indent"
                     if not renpy.macintosh:

--- a/launcher/game/project.rpy
+++ b/launcher/game/project.rpy
@@ -254,6 +254,10 @@ init python in project:
             if persistent.navigate_library:
                 cmd.append("--json-dump-common")
 
+            if persistent.separate_saves:
+                cmd.append("--savedir")
+                cmd.append(self.name)
+
             cmd.append("--errors-in-editor")
 
             environ = dict(os.environ)


### PR DESCRIPTION
This is the meat of my idea for the implementation of #13 - I unfortunately don't know how to build this project to test it, so apologies if I overlooked something! The main issues I suspect would come up would be:

- the project name may need to be adjusted to not have spaces or file-system-unfriendly characters
- the `--savedir` renpy option may not behave the way I expect